### PR TITLE
Fix prompt

### DIFF
--- a/components/keywords.jsx
+++ b/components/keywords.jsx
@@ -58,6 +58,18 @@ export default function ChipsArray() {
     return chipData;
   };
 
+  // Reset keywords list when page is loaded
+  window.addEventListener("load", async (event) => {
+    try {
+      console.log("Resetting Keywords");
+      await axios.post("http://localhost:8800/keywords", {
+        keywords: [],
+      });
+    } catch (error) {
+      console.error("Error resetting keywords:", error);
+    }
+  });
+
   return (
     <Paper
       sx={{

--- a/components/reference-image-paper.jsx
+++ b/components/reference-image-paper.jsx
@@ -99,6 +99,26 @@ export default function ReferenceImagePaper() {
     }
   };
 
+  // Reset description when page is loaded
+  window.addEventListener("load", async (event) => {
+    console.log("Removing Description");
+    // Remove description string from the server
+    try {
+      const response = await axios.post(
+        "http://localhost:8800/description",
+        { description: "" },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      console.log("Description removed successfully");
+    } catch (error) {
+      console.error("Error removing description:", error);
+    }
+  });
+
   /* Conditionally Render the image description and description confidence */
   function Footer({
     isImageUploaded,


### PR DESCRIPTION
The app resets the description and the keywords list on the server when the page is loaded. This means that when a user signs in or signs out, there will no longer be any prompt data that is not shown to the user. 